### PR TITLE
Fix Bern2Time and getpl program and let them cross-platform compatible

### DIFF
--- a/00_bern2time/Makefile
+++ b/00_bern2time/Makefile
@@ -3,8 +3,8 @@ FC_MINGW	:= i686-w64-mingw32.static-gfortran
 
 FCFLAGS= -std=legacy -g
 
-OBJS		= bern2time_FN  bern2time
-OBJS_MINGW	= bern2time_FN.exe  bern2time.exe
+OBJS		= getpl  bern2time_FN  bern2time
+OBJS_MINGW	= getpl.for  bern2time_FN.exe  bern2time.exe
 
 all: $(OBJS)
 

--- a/00_bern2time/Makefile
+++ b/00_bern2time/Makefile
@@ -1,10 +1,12 @@
+## GNU makefile
+
 FC		:= gfortran
 FC_MINGW	:= i686-w64-mingw32.static-gfortran
+FCFLAGS 	:= -std=legacy -g -static -cpp
+FCFLAGS_MINGW 	:= -DMINGW
 
-FCFLAGS= -std=legacy -g
-
-OBJS		= getpl  bern2time_FN  bern2time
-OBJS_MINGW	= getpl.for  bern2time_FN.exe  bern2time.exe
+OBJS		= bern2time_FN  bern2time  getpl
+OBJS_MINGW	= bern2time_FN.exe  bern2time.exe  getpl.exe
 
 all: $(OBJS)
 
@@ -14,7 +16,19 @@ all: $(OBJS)
 mingw: $(OBJS_MINGW)
 
 %.exe: %.for
-	$(FC_MINGW) $(FCFLAGS) -o $@ $^
+	$(FC_MINGW) $(FCFLAGS) $(FCFLAGS_MINGW) -o $@ $^
+
+install: $(OBJS)
+	install -m 0755 $(OBJS) test/
+
+mingw_install: $(OBJS_MINGW)
+	install -m 0755 $(OBJS_MINGW) test/
+
+help:
+	@echo "all:           compile program for Linux or other *nix-like platform"
+	@echo "mingw:         compile program for Win32 platform"
+	@echo "install:       install program for *nix-like platform to test/"
+	@echo "mingw_install: install program for Win32 platform to test/"
 
 clean:
 	rm -f $(OBJS) *.exe

--- a/00_bern2time/bern2time.for
+++ b/00_bern2time/bern2time.for
@@ -44,11 +44,12 @@ c
       end if
 
       inquire(file='fil.dat',exist=alive)
-      if(alive) call system('del fil.dat')
+      if(alive) call system('rm -f fil.dat')
       inquire(file='error.msg',exist=alive)
-      if(alive) call system('del error.msg')
-      call system('del ts_????n_b.gmt ts_????e_b.gmt ts_????h_b.gmt')
-      call system('for %f in (FN??????.OUT) do echo %f >> fil.dat')
+      if(alive) call system('rm -f error.msg')
+      call system('rm -f ts_????n_b.gmt ts_????e_b.gmt ts_????h_b.gmt')
+      call system('for f in $(ls FN??????.OUT);do echo $f;done >> fil.da
+     +t')
 
       open(15,file='fil.dat',status='old')
       stat=0
@@ -60,7 +61,7 @@ c
       rewind(15)
       allocate(outfile(n))
       do i=1,n
-        read(15,'(a12)') inpfile
+        read(15,'(a12)')inpfile
 c        print*,inpfile
         outfile(i)=inpfile(3:8)//'.plh'
 

--- a/00_bern2time/bern2time.for
+++ b/00_bern2time/bern2time.for
@@ -43,6 +43,14 @@ c
         stop
       end if
 
+#ifdef MINGW
+      inquire(file='fil.dat',exist=alive)
+      if(alive) call system('del fil.dat')
+      inquire(file='error.msg',exist=alive)
+      if(alive) call system('del error.msg')
+      call system('del ts_????_n_b.gmt ts_????_e_b.gmt ts_????_h_b.gmt')
+      call system('for %f in (FN??????.OUT) do echo %f >> fil.dat')
+#else
       inquire(file='fil.dat',exist=alive)
       if(alive) call system('rm -f fil.dat')
       inquire(file='error.msg',exist=alive)
@@ -50,6 +58,7 @@ c
       call system('rm -f ts_????n_b.gmt ts_????e_b.gmt ts_????h_b.gmt')
       call system('for f in $(ls FN??????.OUT);do echo $f;done >> fil.da
      +t')
+#endif
 
       open(15,file='fil.dat',status='old')
       n=0
@@ -224,8 +233,13 @@ c***********************************************************************
           close(14)
           close(15)
           close(16)
+#ifdef MINGW
           temp='del '//out1//' '//out2//' '//out3//' '//out4//' '//inp
           call system(temp)
+#else
+          temp='rm -f '//out1//' '//out2//' '//out3//' '//out4//' '//inp
+          call system(temp)
+#endif
           open(11,file='error.msg',position='append')
           write(11,'("Station ",a4," is not found!")')sta(i)
           write(*,'(" Warning!! Station ",a4," is not found!")')sta(i)

--- a/00_bern2time/bern2time.for
+++ b/00_bern2time/bern2time.for
@@ -52,6 +52,7 @@ c
      +t')
 
       open(15,file='fil.dat',status='old')
+      n=0
       stat=0
       do while(stat==0)
         read(15,*,iostat=stat)
@@ -61,16 +62,16 @@ c
       rewind(15)
       allocate(outfile(n))
       do i=1,n
-        read(15,'(a12)')inpfile
-c        print*,inpfile
+        read(15,'(a12)',iostat=stat)inpfile
+        if(stat/=0) exit
+        print*,'Processing '//inpfile//' ...'
         outfile(i)=inpfile(3:8)//'.plh'
-
         open(11,file=inpfile)
         open(12,file=outfile(i))
-
         stat=0
         do while (stat==0)
           read(11,'(a)',iostat=stat) line
+          if(stat/=0) exit
           if(line(1:15)==' FILE TYP FREQ.') then
             t=0.
             t2=24.
@@ -86,21 +87,21 @@ c        print*,inpfile
             if(t2>=23.99999) t=t1
             write(12,'(f7.4)')t
           end if
-          if(line(24:24).eq.'X') then
+          if(line(24:24)=='X') then
             read(line,'(6x,a4)') sta1
-          else if(line(24:29).eq.'HEIGHT') then
+          else if(line(24:29)=='HEIGHT') then
             read(line,'(59x,f9.4,18x,f6.4)')height,herr
             sigh=herr*1000*5
-          else if(line(24:31).eq.'LATITUDE') then
+          else if(line(24:31)=='LATITUDE') then
             read(line,'(54x,i3,1x,i2,1x,f9.6,16x,f6.4)')lat,latm,lats,
-     +      laterr
+     +laterr
             sign=laterr*1000*10
-          else if(line(24:32).eq.'LONGITUDE') then
+          else if(line(24:32)=='LONGITUDE') then
             read(line,'(54x,i3,1x,i2,1x,f9.6,16x,f6.4)')lon,lonm,lons,
-     +      lonerr
+     +lonerr
             sige=lonerr*1000*10
             write(12,'(a4,2(i4,i3,f10.6),f10.4,3f10.2)')sta1,lon,lonm,
-     +      lons,lat,latm,lats,height,sige,sign,sigh
+     +lons,lat,latm,lats,height,sige,sign,sigh
           end if
         end do
 
@@ -112,7 +113,7 @@ c        print*,inpfile
       open (11,file='sta-file')
       sn=0
       stat=0
-      do while (stat.eq.0)
+      do while (stat==0)
         read(11,*,iostat=stat)
         if(stat/=0) exit
         sn=sn+1
@@ -140,28 +141,29 @@ c***********************************************************************
       print*,'Start time_anal'
 
       do i=1,n
-        open (11,file=plhfil(i))
-        read(11,'(f7.4)')tt
-	dy(1:3)=plhfil(i)(3:5)
-	yr(3:4)=plhfil(i)(1:2)
-	if(yr(3:3)=='9') yr(1:2)='19'
-	if(yr(3:3)/='9') yr(1:2)='20'
-	t=yr//' '//dy
+        open(11,file=plhfil(i),status='old')
+        read(11,'(f7.4)',iostat=stat)tt
+        if(stat/=0)exit
+        dy(1:3)=plhfil(i)(3:5)
+        yr(3:4)=plhfil(i)(1:2)
+        if(yr(3:3)=='9') yr(1:2)='19'
+        if(yr(3:3)/='9') yr(1:2)='20'
+        t=yr//' '//dy
         stat=0
         do while (stat==0)
           read(11,'(a4,2(i4,i3,f10.6),f10.4,3f10.2)',iostat=stat)sta1,
-     +    lon,lonm,lons,lat,latm,lats,hgh,ee,en,eh
+     +lon,lonm,lons,lat,latm,lats,hgh,ee,en,eh
           if(stat/=0) exit
           do j=1,sn
-	    if(sta1(1:4)==sta(j)(1:4)) then
+            if(sta1(1:4)==sta(j)(1:4)) then
               out(1:8)=sta(j)//'.out'
-	      open (12,file=out,position='append')
+              open (12,file=out,position='append')
               write(12,'(a8,f8.4,2(i4,i3,f10.6),f10.4,3f10.2)')t,tt,lon,
-     +        lonm,lons,lat,latm,lats,hgh,ee,en,eh
-	      close(12)
+     +lonm,lons,lat,latm,lats,hgh,ee,en,eh
+              close(12)
             end if
           end do
-	end do
+        end do
         close(11,status='delete')
       end do
 
@@ -196,7 +198,7 @@ c***********************************************************************
         out3='ts_'//sta(i)//'_u_b.dat'
         out4='ts_'//sta(i)//'_b.dat'
 
-	open(12,file=inp)
+        open(12,file=inp)
         open(13,file=out1)
         open(14,file=out2)
         open(15,file=out3)
@@ -215,7 +217,7 @@ c***********************************************************************
           if(stat/=0) exit
           n=n+1
         end do
-	if(n==1) then
+        if(n==1) then
           jud=1
           close(12)
           close(13)
@@ -232,55 +234,57 @@ c***********************************************************************
         end if
         rewind(12)
         allocate(yr(n),dy(n),t(n),time(n),hgh(n),se(n),sn(n),sh(n),
-     +  rlon(n),rlat(n),dn(n),de(n),dh(n))
+     +rlon(n),rlat(n),dn(n),de(n),dh(n))
         do k=1,n
-          read(12,'(2i4,f8.4,2(i4,i3,f10.6),f10.4,3f10.2)')yr(k),dy(k),
-     +    t(k),lon,lonm,lons,lat,latm,lats,hgh(k),se(k),sn(k),sh(k)
+          read(12,'(2i4,f8.4,2(i4,i3,f10.6),f10.4,3f10.2)',iostat=stat)y
+     +r(k),dy(k),t(k),lon,lonm,lons,lat,latm,lats,hgh(k),se(k),sn(k)
+     +,sh(k)
+          if(stat/=0) exit
           rlon(k)=lon+lonm/60.+lons/3600.
           rlat(k)=lat+latm/60.+lats/3600.
-	  if(mod(yr(k),4)==0) then
-	    time(k)=real(yr(k))+(real(dy(k))-1.)/366.+t(k)/8784.
-	  else
-	    time(k)=real(yr(k))+(real(dy(k))-1.)/365.+t(k)/8760.
-	  end if
-	  avgn=avgn+rlat(k)
-	  avge=avge+rlon(k)
-	  avgh=avgh+hgh(k)
-	end do
+          if(mod(yr(k),4)==0) then
+            time(k)=real(yr(k))+(real(dy(k))-1.)/366.+t(k)/8784.
+          else
+            time(k)=real(yr(k))+(real(dy(k))-1.)/365.+t(k)/8760.
+          end if
+          avgn=avgn+rlat(k)
+          avge=avge+rlon(k)
+          avgh=avgh+hgh(k)
+        end do
 
- 	avgn=avgn/real(n)
-	avge=avge/real(n)
-	avgh=avgh/real(n)
+         avgn=avgn/real(n)
+        avge=avge/real(n)
+        avgh=avgh/real(n)
 
         call bubble_sort_n(time,yr,dy,t,rlon,rlat,hgh,se,sn,sh,n)
 
         adn=0
         ade=0
         adh=0
-	do k=1,n
-	  londt=cos(avgn*pi/180.)*latdt
-	  dn(k)=(rlat(k)-avgn)*latdt*1000000.-(fvn*(time(k)-time(1)))
-	  de(k)=(rlon(k)-avge)*londt*1000000.-(fve*(time(k)-time(1)))
-	  dh(k)=(hgh(k)-avgh)*1000.-(fvh*(time(k)-time(1)))
-	  adn=adn+dn(k)
-	  ade=ade+de(k)
-	  adh=adh+dh(k)
-	end do
-	adn=adn/real(n)
-	ade=ade/real(n)
-	adh=adh/real(n)
-	do k=1,n
-	  write(13,'(f10.5,1x,2f8.2)') time(k),dn(k)-adn,sn(k)
-	  write(14,'(f10.5,1x,2f8.2)') time(k),de(k)-ade,se(k)
-	  write(15,'(f10.5,1x,2f8.2)') time(k),dh(k)-adh,sh(k)
-	  write(16,'(2i4,f8.4,1x,6f8.2)') yr(k),dy(k),t(k),dn(k)-adn,
-     +    sn(k),de(k)-ade,se(k),dh(k)-adh,sh(k)
+        do k=1,n
+          londt=cos(avgn*pi/180.)*latdt
+          dn(k)=(rlat(k)-avgn)*latdt*1000000.-(fvn*(time(k)-time(1)))
+          de(k)=(rlon(k)-avge)*londt*1000000.-(fve*(time(k)-time(1)))
+          dh(k)=(hgh(k)-avgh)*1000.-(fvh*(time(k)-time(1)))
+          adn=adn+dn(k)
+          ade=ade+de(k)
+          adh=adh+dh(k)
+        end do
+        adn=adn/real(n)
+        ade=ade/real(n)
+        adh=adh/real(n)
+        do k=1,n
+          write(13,'(f10.5,1x,2f8.2)') time(k),dn(k)-adn,sn(k)
+          write(14,'(f10.5,1x,2f8.2)') time(k),de(k)-ade,se(k)
+          write(15,'(f10.5,1x,2f8.2)') time(k),dh(k)-adh,sh(k)
+          write(16,'(2i4,f8.4,1x,6f8.2)') yr(k),dy(k),t(k),dn(k)-adn,
+     +sn(k),de(k)-ade,se(k),dh(k)-adh,sh(k)
         end do
         close(12,status='delete')
-	close(13)
-	close(14)
-	close(15)
-	close(16)
+        close(13)
+        close(14)
+        close(15)
+        close(16)
 
         deallocate(yr,dy,t,time,hgh,se,sn,sh,rlon,rlat,dn,de,dh)
       end do

--- a/00_bern2time/bern2time_FN.for
+++ b/00_bern2time/bern2time_FN.for
@@ -43,14 +43,23 @@ c
         stop
       end if
 
+#ifdef MINGW
+      inquire(file='fil.dat',exist=alive)
+      if(alive) call system('del fil.dat')
+      inquire(file='error.msg',exist=alive)
+      if(alive) call system('del error.msg')
+      call system('del ts_????_n_b.dat ts_????_e_b.dat ts_????_u_b.dat')
+      call system('for %f in (FN??????.OUT) do echo %f >> fil.dat')
+#else
       inquire(file='fil.dat',exist=alive)
       if(alive) call system('rm -f fil.dat')
       inquire(file='error.msg',exist=alive)
       if(alive) call system('rm -f error.msg')
       call system('rm -f ts_????_n_b.dat ts_????_e_b.dat ts_????_u_b.dat
      +')
-      call system('for f in $(ls FN?????1.OUT);do echo $f;done >> fil.da
+      call system('for f in $(ls FN??????.OUT);do echo $f;done >> fil.da
      +t')
+#endif
 
       open(15,file='fil.dat',status='old')
       n=0
@@ -228,7 +237,11 @@ c***********************************************************************
           close(14)
           close(15)
           close(16)
+#ifdef MINGW
           temp='del '//out1//' '//out2//' '//out3//' '//out4//' '//inp
+#else
+          temp='rm -f '//out1//' '//out2//' '//out3//' '//out4//' '//inp
+#endif
           call system(temp)
           open(11,file='error.msg',position='append')
           write(11,'("Station ",a4," is not found!")')sta(i)

--- a/00_bern2time/getpl.for
+++ b/00_bern2time/getpl.for
@@ -13,9 +13,13 @@ c
       logical alive
 
       inquire(file='fil.dat',exist=alive)
+#ifdef MINGW
+      if(alive) call system('del fil.dat')
+      call system('for %f in (FN??????.OUT) do echo %f >> fil.dat')
+#else
       if(alive) call system('rm -f fil.dat')
-      call system('(for f in $(ls FN?????1.OUT);do echo $f;done) > fil.d
-     +at')
+      call system('for f in $(ls FN??????.OUT);do echo $f;done>fil.dat')
+#endif
 
       open(12,file='tmp')
       open(15,file='fil.dat',status='old')
@@ -27,7 +31,8 @@ c
       end do
       rewind(15)
       do i=1,n
-        read(15,'(a13)') inpfile
+        read(15,'(a13)',iostat=stat) inpfile
+        if(stat/=0) exit
         print*,'Processing '//inpfile//' ...'
         open(11,file=inpfile)
         stat=0

--- a/00_bern2time/getpl.for
+++ b/00_bern2time/getpl.for
@@ -1,0 +1,139 @@
+c--     by Kuo-En Ching 2005.01.13
+c--              Update 2005.09.19
+c
+c
+      program getpl
+      
+      implicit none
+      character line*200,sta1*4,inpfile*13
+      character,allocatable::sta(:)*4
+      real*8 lats,lons,hgh,lat,lon
+      double precision,allocatable::phy(:),lda(:)
+      integer i,j,n,latd,lond,latm,lonm,stat,ty
+      logical alive
+
+      inquire(file='fil.dat',exist=alive)
+      if(alive) call system('rm -f fil.dat')
+      call system('(for f in $(ls FN?????1.OUT);do echo $f;done) > fil.d
+     +at')
+
+      open(12,file='tmp')
+      open(15,file='fil.dat',status='old')
+      stat=0
+      do while(stat==0)
+        read(15,*,iostat=stat)
+        if(stat/=0) exit
+        n=n+1
+      end do
+      rewind(15)
+      do i=1,n
+        read(15,'(a13)') inpfile
+        print*,inpfile
+        open(11,file=inpfile)
+        stat=0
+        do while (stat==0)
+          read(11,'(a)',iostat=stat) line
+          if(line(24:24).eq.'X') then
+            read(line,'(6x,a4)') sta1
+          else if(line(24:29).eq.'HEIGHT') then
+            read(line,'(59x,f9.4)')hgh
+          else if(line(24:31).eq.'LATITUDE') then
+            read(line,'(54x,i3,1x,i2,1x,f9.6)')latd,latm,lats
+            lat=real(latd)+real(latm)/60.+lats/3600.
+          else if(line(24:32).eq.'LONGITUDE') then
+            read(line,'(54x,i3,1x,i2,1x,f9.6)')lond,lonm,lons
+            lon=real(lond)+real(lonm)/60.+lons/3600.
+            write(12,'(a4,1x,2f8.4,f10.4)')sta1,lon,lat,hgh
+          end if
+        end do
+        close(11)
+      end do
+      close(15,status='delete')
+      close(12)
+      
+      open(12,file='tmp',status='old')
+      n=0
+      stat=0
+      do while (stat==0)
+        read(12,*,iostat=stat)
+        if(stat/=0) exit
+        n=n+1
+      end do
+      rewind(12)
+      allocate(sta(n),phy(n),lda(n))
+      do i=1,n
+        read(12,*)sta(i),lda(i),phy(i)
+      end do
+      close(12,status='delete')
+
+      open(12,file='getpl_o.gout')
+      write(12,'(a4,1x,2f8.4)')sta(1),lda(1),phy(1)
+      do i=2,n
+        ty=0
+        do j=1,i-1
+          if(sta(i)==sta(j)) then
+            ty=1
+            exit
+          end if
+        end do
+        if(ty==1) cycle
+        write(12,'(a4,1x,2f8.4)')sta(i),lda(i),phy(i)
+      end do
+      deallocate(sta,phy,lda)
+      rewind(12)
+      n=0
+      stat=0
+      do while (stat==0)
+      read(12,*,iostat=stat)
+        if(stat/=0) exit
+        n=n+1
+      end do
+      rewind(12)
+      allocate(sta(n),phy(n),lda(n))
+      do i=1,n
+        read(12,*)sta(i),lda(i),phy(i)
+      end do
+      close(12,status='delete')
+      
+      call bubble_sort(sta,phy,lda,n)
+
+      open(12,file='getpl.gout')
+      open(13,file='sta-file')
+      do i=1,n
+        write(12,'(a4,1x,2f8.4)')sta(i),lda(i),phy(i)
+        write(13,'(a4)')sta(i)
+      end do
+      close(12)
+      close(13)
+
+      deallocate(sta,phy,lda)
+
+      stop
+      end
+
+c.......................................................................
+      subroutine bubble_sort(a,b,c,n)
+      implicit none
+      integer n
+      real*8 b(n),c(n),temp2,temp3
+      character a(n)*4,temp1*4
+      integer i,j
+      
+      do i=n-1,1,-1
+        do j=1,i
+          if(a(j).gt.a(j+1)) then
+            temp1=a(j)
+            temp2=b(j)
+            temp3=c(j)
+            a(j)=a(j+1)
+            b(j)=b(j+1)
+            c(j)=c(j+1)
+            a(j+1)=temp1
+            b(j+1)=temp2
+            c(j+1)=temp3
+          end if
+        end do
+      end do
+      
+      return
+      end

--- a/00_bern2time/getpl.for
+++ b/00_bern2time/getpl.for
@@ -28,7 +28,7 @@ c
       rewind(15)
       do i=1,n
         read(15,'(a13)') inpfile
-        print*,inpfile
+        print*,'Processing '//inpfile//' ...'
         open(11,file=inpfile)
         stat=0
         do while (stat==0)

--- a/00_bern2time/getpl.for
+++ b/00_bern2time/getpl.for
@@ -3,7 +3,7 @@ c--              Update 2005.09.19
 c
 c
       program getpl
-      
+
       implicit none
       character line*200,sta1*4,inpfile*13
       character,allocatable::sta(:)*4
@@ -50,7 +50,7 @@ c
       end do
       close(15,status='delete')
       close(12)
-      
+
       open(12,file='tmp',status='old')
       n=0
       stat=0
@@ -94,7 +94,7 @@ c
         read(12,*)sta(i),lda(i),phy(i)
       end do
       close(12,status='delete')
-      
+
       call bubble_sort(sta,phy,lda,n)
 
       open(12,file='getpl.gout')
@@ -118,7 +118,7 @@ c.......................................................................
       real*8 b(n),c(n),temp2,temp3
       character a(n)*4,temp1*4
       integer i,j
-      
+
       do i=n-1,1,-1
         do j=1,i
           if(a(j).gt.a(j+1)) then
@@ -134,6 +134,6 @@ c.......................................................................
           end if
         end do
       end do
-      
+
       return
       end


### PR DESCRIPTION
- [x] fix EOF read data error
  * add `n=0` before use `n` variable to count.
  * use `iostat` in some `read()` function, to let some EOF status can be exited normally
  * refine indent, convert for TAB to 8 whitspaces to keep the layout
- [x]  getpl, bern2time: let exec commands cross-platform compact

---

now `bern2time`, and `getpl` program can be rebuild by yourself now!